### PR TITLE
Fix a core option and bump version number

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2211,7 +2211,7 @@ static bool initial_ports_hookup = false;
 
 #define MEDNAFEN_CORE_NAME_MODULE "vb"
 #define MEDNAFEN_CORE_NAME "Beetle VB"
-#define MEDNAFEN_CORE_VERSION "v0.9.36.1"
+#define MEDNAFEN_CORE_VERSION "v1.27.1"
 #define MEDNAFEN_CORE_EXTENSIONS "vb|vboy|bin"
 #define MEDNAFEN_CORE_TIMING_FPS 50.27
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W (EmulatedVB.nominal_width)

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -118,7 +118,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "fast",      NULL },
          { NULL, NULL},
       },
-      "disabled",
+      "accurate",
    },
    { NULL, NULL, NULL, { NULL, NULL }, NULL },
 };

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -118,7 +118,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "fast",      NULL },
          { NULL, NULL},
       },
-      "accurate",
+      "fast",
    },
    { NULL, NULL, NULL, { NULL, NULL }, NULL },
 };

--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -143,7 +143,7 @@ struct retro_core_option_definition option_defs_tr[] = {
          { "fast",      "hızlı" },
          { NULL, NULL},
       },
-      "accurate",
+      "fast",
    },
    { NULL, NULL, NULL, { NULL, NULL }, NULL },
 };

--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -143,7 +143,7 @@ struct retro_core_option_definition option_defs_tr[] = {
          { "fast",      "hızlı" },
          { NULL, NULL},
       },
-      "disabled",
+      "accurate",
    },
    { NULL, NULL, NULL, { NULL, NULL }, NULL },
 };


### PR DESCRIPTION
Upon further inspection, the CPU core option in beetle-vb-libretro was set to disabled and as far as I can see there is only fast and accurate to choose from to begin with.

I took the liberty and changed it from disabled to accurate as default, end users can always change it later on.

Also, the beetle-vb-libretro core must be somewhat up to date so I also took the liberty and bumped the version number to match the recent Mednafen 1.27.1 release.

This is just a proposal PR, feel free to change or close it if you want.