### PR TITLE
Add button to trigger low-battery sensor

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2441,6 +2441,7 @@ static void check_variables(void)
 #define MAX_PLAYERS 1
 #define MAX_BUTTONS 14
 static uint16_t input_buf[MAX_PLAYERS];
+static uint16_t low_battery;
 
 static void hookup_ports(bool force)
 {
@@ -2449,6 +2450,7 @@ static void hookup_ports(bool force)
 
    /* Possible endian bug ... */
    VBINPUT_SetInput(0, "gamepad", &input_buf[0]);
+   VBINPUT_SetInput(1, "gamepad", &low_battery);
 
    initial_ports_hookup = true;
 }
@@ -2612,6 +2614,20 @@ static void update_input(void)
       u.s = input_buf[j];
       input_buf[j] = u.b[0] | u.b[1] << 8;
 #endif
+   }
+   // For low-battery mode switch
+   {
+      static int pressed;
+      if ((joy_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_X)) || 
+         (joy_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)))
+      {
+         if (!pressed)
+         {
+            pressed ^= 1;
+            low_battery ^= 1;
+         }
+      } else
+         pressed = 0;
    }
 }
 

--- a/mednafen/vb/input.c
+++ b/mednafen/vb/input.c
@@ -26,7 +26,7 @@ static bool InstantReadHack;
 
 static bool IntPending;
 
-static uint8 *data_ptr;
+static uint8* data_ptr[2];
 
 static uint16 PadData;
 static uint16 PadLatched;
@@ -59,7 +59,7 @@ void VBINPUT_SetInstantReadHack(bool enabled)
 
 void VBINPUT_SetInput(int port, const char *type, void *ptr)
 {
-   data_ptr = (uint8 *)ptr;
+   data_ptr[port] = (uint8 *)ptr;
 }
 
 uint8 VBINPUT_Read(v810_timestamp_t timestamp, uint32 A)
@@ -137,7 +137,7 @@ static INLINE uint16_t MDFN_de16lsb(const uint8_t *morp)
 
 void VBINPUT_Frame(void)
 {
-   PadData = (MDFN_de16lsb(data_ptr) << 2) | 0x2;
+   PadData = (MDFN_de16lsb(data_ptr[0]) << 2) | 0x2 | (*data_ptr[1] & 0x1);
 }
 
 v810_timestamp_t VBINPUT_Update(const v810_timestamp_t timestamp)


### PR DESCRIPTION
By default, button X or Y is used as the trigger

https://github.com/libretro/beetle-vb-libretro/issues/63