### PR TITLE
PS3/PSL1GHT Makefile update and gcc4.x compatibility added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,18 +206,18 @@ else ifeq ($(platform), qnx)
    AR = QCC -Vgcc_ntoarmv7le
    FLAGS += -D__BLACKBERRY_QNX__ -marm -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=softfp
 
-# PS3
-else ifneq (,$(filter $(platform), psl1ght))
+# Lightweight PS3 Homebrew SDK
+else ifneq (,$(filter $(platform), ps3 psl1ght))
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    ENDIANNESS_DEFINES := -DMSB_FIRST
    STATIC_LINKING = 1
-
-   # Lightweight PS3 Homebrew SDK
-   ifneq (,$(findstring psl1ght,$(platform)))
-      CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
-      CXX = $(PS3DEV)/ppu/bin/ppu-g++$(EXE_EXT)
-      AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
+   CC = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)gcc$(EXE_EXT)
+   CXX = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)g++$(EXE_EXT)
+   AR = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)ar$(EXE_EXT)
+   ifeq ($(platform), psl1ght)
+		FLAGS += -D__PSL1GHT__
    endif
+   FLAGS += -D__PS3__
 
 # PSP
 else ifeq ($(platform), psp1)

--- a/mednafen/hw_cpu/v810/fpu-new/mednafen-gcc.h
+++ b/mednafen/hw_cpu/v810/fpu-new/mednafen-gcc.h
@@ -9,12 +9,14 @@
 | to the same as `int'.
 *----------------------------------------------------------------------------*/
 typedef char flag;
+#ifndef __MDFN_TYPES
 typedef uint8_t uint8;
 typedef int8_t int8;
 typedef uint16_t uint16;
 typedef int16_t int16;
 typedef uint32_t uint32;
 typedef int32_t int32;
+#endif
 
 /*----------------------------------------------------------------------------
 | Each of the following `typedef's defines a type that holds integers

--- a/mednafen/hw_cpu/v810/fpu-new/softfloat.c
+++ b/mednafen/hw_cpu/v810/fpu-new/softfloat.c
@@ -39,8 +39,8 @@ these four paragraphs for those parts of this code that are retained.
 */
 
 
-#include "mednafen-gcc.h"
 #include "softfloat.h"
+#include "mednafen-gcc.h"
 
 /*----------------------------------------------------------------------------
 | Floating-point rounding mode and exception flags.


### PR DESCRIPTION
```
In file included from mednafen/hw_cpu/v810/fpu-new/softfloat.h:37,
                 from mednafen/hw_cpu/v810/fpu-new/softfloat.c:43:
mednafen/hw_cpu/v810/fpu-new/../../../mednafen-types.h:6: error: redefinition of typedef 'int8'
mednafen/hw_cpu/v810/fpu-new/mednafen-gcc.h:14: error: previous declaration of 'int8' was here
```
Now it's compilable on gcc 4.x